### PR TITLE
refactor: extract owned object mixin

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,5 @@
 FROM mcr.microsoft.com/devcontainers/python:1-3.11-bullseye
 
 ENV PYTHONUNBUFFERED 1
+
+RUN rm /usr/local/py-utils/bin/pytest

--- a/.github/workflows/review-build.yaml
+++ b/.github/workflows/review-build.yaml
@@ -1,9 +1,9 @@
-name: Lint
+name: Review Build
 
 on: pull_request
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,5 +37,11 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       # Lint
+
       - name: Lint
         run: poetry run pre-commit run --all-files --show-diff-on-failure
+
+      # Test
+
+      - name: Run Tests
+        run: poetry run pytest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,15 @@
         "source.fixAll": true
     },
     "editor.formatOnSave": true,
+    "python.analysis.extraPaths": [
+        "wishlists"
+    ],
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
-    }
+    },
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -470,6 +470,17 @@ files = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -548,6 +559,21 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
 
 [[package]]
+name = "pluggy"
+version = "1.3.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "pre-commit"
 version = "3.6.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -618,6 +644,44 @@ crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+
+[[package]]
+name = "pytest"
+version = "7.4.4"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
+    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-django"
+version = "4.7.0"
+description = "A Django plugin for pytest."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-django-4.7.0.tar.gz", hash = "sha256:92d6fd46b1d79b54fb6b060bbb39428073396cec717d5f2e122a990d4b6aa5e8"},
+    {file = "pytest_django-4.7.0-py3-none-any.whl", hash = "sha256:4e1c79d5261ade2dd58d91208017cd8f62cb4710b56e012ecd361d15d5d662a2"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["Django", "django-configurations (>=2.0)"]
 
 [[package]]
 name = "python3-openid"
@@ -854,4 +918,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b1c7e2b7402e4e6c2c70f7e954f1b7a3069d7b6456a4bd2277575f659f4b7f55"
+content-hash = "746caab3cf0f6cdef31e4b9f449aaffd71240e714ec0391c43f5fc224966407b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,13 @@ black = "^23.12.1"
 pre-commit = "^3.6.0"
 django-browser-reload = "^1.12.1"
 ruff = "^0.1.13"
+pytest = "^7.4.4"
+pytest-django = "^4.7.0"
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "wishlists.settings"
+pythonpath = ["wishlists"]
+testpaths = ["tests"]
 
 [tool.ruff.lint]
 extend-select = [
@@ -31,6 +38,8 @@ extend-select = [
     "I",
     # flake8-django
     "DJ",
+    # flake8-pytest-style
+    "PT",
     # Unnecessary error suppression
     "RUF100",
 ]

--- a/tests/unit/core/mixins/test_owned_object_mixin.py
+++ b/tests/unit/core/mixins/test_owned_object_mixin.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+import pytest
+from core.mixins import OwnedObjectMixin
+
+
+class MockParentView:
+    def __init__(self, queryset):
+        self.queryset = queryset
+
+    def get_queryset(self):
+        return self.queryset
+
+
+class DefaultsView(OwnedObjectMixin, MockParentView):
+    pass
+
+
+class OverriddenView(OwnedObjectMixin, MockParentView):
+    object_owner_field = "some_other_field"
+
+
+@pytest.fixture()
+def queryset():
+    return mock.MagicMock(name="QuerySet")
+
+
+def test_get_queryset_defaults(queryset):
+    request = mock.MagicMock(spec="django.http.HttpRequest")
+    request.user = mock.MagicMock(name="User")
+
+    view = DefaultsView(queryset)
+    view.request = request
+
+    received = view.get_queryset()
+
+    assert received == queryset.filter.return_value
+    queryset.filter.assert_called_once_with(owner=request.user)
+
+
+def test_get_queryset_custom_owner_field(queryset):
+    request = mock.MagicMock(spec="django.http.HttpRequest")
+    request.user = mock.MagicMock(name="User")
+
+    view = OverriddenView(queryset)
+    view.request = request
+
+    received = view.get_queryset()
+
+    assert received == queryset.filter.return_value
+    queryset.filter.assert_called_once_with(some_other_field=request.user)

--- a/wishlists/core/mixins.py
+++ b/wishlists/core/mixins.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models.query import QuerySet
+
+
+class OwnedObjectMixin(LoginRequiredMixin):
+    object_owner_field = "owner"
+
+    def get_queryset(self) -> QuerySet[Any]:
+        filter = {self.object_owner_field: self.request.user}
+
+        return super().get_queryset().filter(**filter)

--- a/wishlists/core/views.py
+++ b/wishlists/core/views.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.db.models.query import QuerySet
 from django.forms.models import BaseModelForm
 from django.http import HttpResponse
 from django.urls import reverse_lazy
@@ -12,6 +11,7 @@ from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
 
 from core import models
+from core.mixins import OwnedObjectMixin
 
 
 class IdeaCollectionCreateView(LoginRequiredMixin, CreateView):
@@ -26,7 +26,7 @@ class IdeaCollectionCreateView(LoginRequiredMixin, CreateView):
         return super().form_valid(form)
 
 
-class IdeaCollectionDeleteView(LoginRequiredMixin, DeleteView):
+class IdeaCollectionDeleteView(OwnedObjectMixin, DeleteView):
     context_object_name = "idea_collection"
     model = models.IdeaCollection
     success_url = reverse_lazy("idea-collection-list")
@@ -51,42 +51,28 @@ class IdeaCollectionDeleteView(LoginRequiredMixin, DeleteView):
 
         return context
 
-    def get_queryset(self) -> QuerySet[models.IdeaCollection]:
-        return super().get_queryset().filter(owner=self.request.user)
 
-
-class IdeaCollectionListView(LoginRequiredMixin, ListView):
+class IdeaCollectionListView(OwnedObjectMixin, ListView):
     context_object_name = "idea_collections"
     model = models.IdeaCollection
     template_name = "core/ideacollection_list.html"
 
-    def get_queryset(self) -> QuerySet[models.IdeaCollection]:
-        return super().get_queryset().filter(owner=self.request.user)
 
-
-class IdeaCollectionUpdateView(LoginRequiredMixin, UpdateView):
+class IdeaCollectionUpdateView(OwnedObjectMixin, UpdateView):
     context_object_name = "idea_collection"
     model = models.IdeaCollection
     fields = ["name"]
     template_name_suffix = "_update_form"
 
-    def get_queryset(self) -> QuerySet[models.IdeaCollection]:
-        return super().get_queryset().filter(owner=self.request.user)
 
-
-class IdeaCollectionDetailView(LoginRequiredMixin, DetailView):
+class IdeaCollectionDetailView(OwnedObjectMixin, DetailView):
     context_object_name = "idea_collection"
     model = models.IdeaCollection
     template_name = "core/ideacollection_detail.html"
 
-    def get_queryset(self) -> QuerySet[models.IdeaCollection]:
-        return super().get_queryset().filter(owner=self.request.user)
 
-
-class GiftIdeaDetailView(LoginRequiredMixin, DetailView):
+class GiftIdeaDetailView(OwnedObjectMixin, DetailView):
     context_object_name = "gift_idea"
     model = models.GiftIdea
+    object_owner_field = "collection__owner"
     template_name = "core/giftidea_detail.html"
-
-    def get_queryset(self) -> QuerySet[models.GiftIdea]:
-        return super().get_queryset().filter(collection__owner=self.request.user)


### PR DESCRIPTION
Create a mixin to hold the logic for filtering a view that utilizes `get_queryset` to only objects owned by the user making the request.
